### PR TITLE
UGC-4247 | Widgets+DPL no longer work in PortableInfoboxes

### DIFF
--- a/WidgetRenderer.php
+++ b/WidgetRenderer.php
@@ -151,10 +151,10 @@ class WidgetRenderer {
 	}
 
 	/**
-	 * @param Parser $parser
-	 * @param string &$text
+	 * @param OutputPage $out
+	 * @param ParserOutput $parserOutput
 	 */
-	public static function outputCompiledWidget( $parser, &$text ) {
+	public static function outputCompiledWidget( OutputPage $out, ParserOutput $parserOutput ) {
 		$replacements = self::$widgets;
 		if ( empty( $replacements ) ) {
 			return;
@@ -164,7 +164,9 @@ class WidgetRenderer {
 			static function ( $matches ) use ( $replacements ) {
 				return $replacements[$matches[1]];
 			},
-			$text
+			$parserOutput->getText()
 		);
+
+		$parserOutput->setText( $text );
 	}
 }

--- a/extension.json
+++ b/extension.json
@@ -1,11 +1,7 @@
 {
 	"name": "Widgets",
 	"version": "1.4.2",
-	"author": [
-		"[https://www.sergeychernyshev.com Sergey Chernyshev]",
-		"Yaron Koren",
-		"..."
-	],
+	"author": ["[https://www.sergeychernyshev.com Sergey Chernyshev]", "Yaron Koren", "..."],
 	"url": "https://www.mediawiki.org/wiki/Extension:Widgets",
 	"descriptionmsg": "widgets-desc",
 	"license-name": "GPL-2.0-or-later",
@@ -43,11 +39,9 @@
 	],
 	"Hooks": {
 		"ParserFirstCallInit": "WidgetInitializer::initParserFunctions",
-		"ParserAfterTidy": "WidgetRenderer::outputCompiledWidget"
+		"OutputPageParserOutput": "WidgetRenderer::outputCompiledWidget"
 	},
-	"AvailableRights": [
-		"editwidgets"
-	],
+	"AvailableRights": ["editwidgets"],
 	"GroupPermissions": {
 		"*": {
 			"editwidgets": false
@@ -60,9 +54,7 @@
 		}
 	},
 	"MessagesDirs": {
-		"Widgets": [
-			"i18n"
-		]
+		"Widgets": ["i18n"]
 	},
 	"ExtensionMessagesFiles": {
 		"WidgetsMagic": "Widgets.i18n.magic.php",


### PR DESCRIPTION
## Links
* https://fandom.atlassian.net/browse/UGC-4247

## Description
Something strange happens in the parser hooks functions call order.
`Widgets` extension can't output compiled widgets in PortableInfobox because the infobox does not exist at the time of executing `ParserAfterTidy` hook which both of the extensions use to replace markers with actual values. That happens because the parser first executes `Widgets` hook and just after that `PortableInfobox` hook.

By changing the hook of `WidgetsRenderer` we are sure that the full article content is parsed before we try to replace widgets markers with an actual value.

## Screenshots

#### Before:
![image](https://github.com/Wikia/mediawiki-Widgets/assets/50043764/b02f3b57-46a8-4291-9212-3de3a639defc)
![image](https://github.com/Wikia/mediawiki-Widgets/assets/50043764/be84a8b2-b57d-48c5-bc4c-b6d37dcc71b2)

#### After:
![image](https://github.com/Wikia/mediawiki-Widgets/assets/50043764/9127ff10-5c1d-430f-bc41-8bc4bb971ab8)
![image](https://github.com/Wikia/mediawiki-Widgets/assets/50043764/75e5446d-aa08-454e-9ed5-87de065339b8)



